### PR TITLE
fix type error provider-ipcsocket.ts

### DIFF
--- a/src.ts/providers/provider-ipcsocket.ts
+++ b/src.ts/providers/provider-ipcsocket.ts
@@ -57,7 +57,7 @@ export class IpcSocketProvider extends SocketProvider {
             messages.forEach((message) => {
                 this._processMessage(message);
             });
-            response = remaining;
+            response = Buffer.from(remaining);
         });
 
         this.socket.on("end", () => {


### PR DESCRIPTION
fix error node_modules/.pnpm/ethers@6.14.1/node_modules/ethers/src.ts/providers/provider-ipcsocket.ts:60:13 - error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'Buffer<ArrayBuffer>'.